### PR TITLE
fix: reject hex strings containing non-hex characters

### DIFF
--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -63,3 +63,8 @@ test("valid input is valid", () => {
 	expect(isValidColor(hex("#12345"))).toBeFalsy()
 	expect(isValidColor(hex("#1234567"))).toBeFalsy()
 })
+
+test("rejects non-hex characters in any position", () => {
+	expect(isValidColor(hex("#abcdeg"))).toBeFalsy()
+	expect(isValidColor(hex("#00115g"))).toBeFalsy()
+})

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -6,7 +6,8 @@ const isShortHex = (input: string): boolean => input.length === 3 || input.lengt
 const isAlpha = (input: string): boolean => input.length === 4 || input.length === 8
 
 const isHex = (input: string): boolean => {
-	return [3, 4, 6, 8].some((l) => removeHash(input).length === l)
+	const text = removeHash(input)
+	return [3, 4, 6, 8].some((l) => text.length === l) && /^[0-9a-f]+$/i.test(text)
 }
 
 const trimInput = (input: string): string => {


### PR DESCRIPTION
`hex()` accepts strings containing non-hex characters and silently returns a wrong (but valid-looking) color instead of `[NaN, NaN, NaN]`, contradicting the documented contract that invalid input yields a `NaN` triplet.

`isHex` only checks the length of the stripped string (3/4/6/8), never that the characters are hex digits. Character validation is left to `Number.parseInt(chunk, 16)`, which is lenient: it parses a leading valid prefix and ignores the rest. So a bad character in the first slot of a chunk (`"gg"` -> `NaN`) is rejected, but a bad character in the second slot is not:

```ts
hex("#abcdeg") // -> [171, 205, 14]   (expected [NaN, NaN, NaN]); "eg" -> parseInt("eg", 16) = 14
hex("#00115g") // -> [0, 17, 5]       (expected [NaN, NaN, NaN]); "5g" -> parseInt("5g", 16) = 5
isValidColor(hex("#abcdeg")) // true, so callers can't detect the malformed input
```

The existing `#0011gg` test only passes by luck — the invalid char happens to land in the first slot of its chunk.

Fix: validate the character set in `isHex` in addition to the length. Added a regression test covering a bad character in a non-leading position.
